### PR TITLE
feat: add golang to darwin and set go paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,15 +81,8 @@ __am-prompt-install() {
     fi
 
     local GIT_PROMPT_NAME=git-prompt.sh
-    local GIT_COMPLETE_NAME=git-flow-completion.bash
     local GIT_PROMPT_URI=https://raw.githubusercontent.com/lyze/posh-git-sh/master/$GIT_PROMPT_NAME
-    local GIT_COMPLETE_URI=https://raw.githubusercontent.com/petervanderdoes/git-flow-completion/develop/$GIT_COMPLETE_NAME
     local PROMPT_COMPLETION="$AM_PROMPT/completions"
-
-    if [ -f "$BASH_COMPLETION/$GIT_COMPLETE_NAME" ]; then
-        __am-prompt-success 'removing git flow bash completion'
-        rm -rf "$BASH_COMPLETION/$GIT_COMPLETE_NAME" 1>/dev/null
-    fi
 
     if [ -f "$BASH_COMPLETION/$GIT_PROMPT_NAME" ]; then
         __am-prompt-success 'removing crappy git-prompt'
@@ -106,14 +99,6 @@ __am-prompt-install() {
     if [ "$CURL_RESULT" = "200" ]; then
         __am-prompt-success 'successfully installed git-prompt'
         chmod +x "PROMPT_COMPLETION/$GIT_PROMPT_NAME" 1>/dev/null 2>&1
-    fi
-
-    __am-prompt-success 'downloading git-flow completion'
-    local CURL_RESULT=$(curl -sLD- "$GIT_COMPLETE_URI" -o "$PROMPT_COMPLETION/$GIT_COMPLETE_NAME" -# | grep "^HTTP/1.1" | head -n 1 | sed "s/HTTP.1.1 \([0-9]*\).*/\1/")
-
-    if [ "$CURL_RESULT" = "200" ]; then
-        __am-prompt-success 'successfully installed git-flow completion'
-        chmod +x "$PROMPT_COMPLETION/$GIT_COMPLETE_NAME" 1>/dev/null 2>&1
     fi
 
     local CURL_OPT='-s'

--- a/src/scripts/eval/set-go-path
+++ b/src/scripts/eval/set-go-path
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# detect if go is installed and gopath is not already set
+if type go 1>/dev/null 2>&1; then
+
+    # export the go path
+    export GOPATH=${GOPATH:-$HOME/.go}
+
+    # export the go bin
+    export GOBIN=${GOBIN:-$GOPATH/bin}
+fi
+
+# determine if go bin is specified
+if [ ! -z "${GOBIN}" ]; then
+    # add the go bin to the path
+    export PATH=$PATH:$GOBIN
+fi
+

--- a/uname/install-Darwin.sh
+++ b/uname/install-Darwin.sh
@@ -19,7 +19,7 @@ __am-prompt-install-darwin() {
         fi
     done
 
-    for pkg in bash openssl git git-extras git-flow-avh nvm bash-completion; do
+    for pkg in bash openssl git go nvm bash-completion; do
         if brew list -1 | grep -q "^${pkg}\$"; then
             __am-prompt-success "upgrading: $pkg"
             brew upgrade $pkg 1>/dev/null 2>&1

--- a/uname/install-debian.sh
+++ b/uname/install-debian.sh
@@ -5,7 +5,6 @@ success() {
     echo -e "${CLR_SUCCESS}$1${CLR_CLEAR}"
 }
 
-sudo add-apt-repository ppa:pdoes/gitflow-avh -y 1>/dev/null 2>&1
 sudo add-apt-repository ppa:git-core/ppa -y 1>/dev/null 2>&1
 sudo apt-get update 1>/dev/null
 
@@ -15,7 +14,7 @@ for pkg in git-flow; do
     fi
 done
 
-for pkg in openssl git git-extras git-flow build-essential libssl-dev curl libunwind8 gettext; do
+for pkg in openssl git build-essential libssl-dev curl libunwind8 gettext; do
     success "Installing $pkg..."
     sudo apt-get install -y ${pkg}
 done

--- a/uname/install-fedora.sh
+++ b/uname/install-fedora.sh
@@ -17,5 +17,3 @@ source "$NVM_DIR/nvm.sh"
 
 nvm install --lts 1>/dev/null
 nvm use --lts --delete-prefix 1>/dev/null
-
-wget --no-check-certificate -q  https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh && sudo bash gitflow-installer.sh install stable; rm gitflow-installer.sh

--- a/uname/install-ubuntu.sh
+++ b/uname/install-ubuntu.sh
@@ -5,7 +5,6 @@ success() {
     echo -e "${CLR_SUCCESS}$1${CLR_CLEAR}"
 }
 
-sudo add-apt-repository ppa:pdoes/gitflow-avh -y 1>/dev/null 2>&1
 sudo add-apt-repository ppa:git-core/ppa -y 1>/dev/null 2>&1
 sudo apt-get update 1>/dev/null
 
@@ -15,7 +14,7 @@ for pkg in git-flow; do
     fi
 done
 
-for pkg in openssl git git-extras git-flow build-essential libssl-dev curl libunwind8 gettext; do
+for pkg in openssl git build-essential libssl-dev curl libunwind8 gettext; do
     success "Installing $pkg..."
     sudo apt-get install -y ${pkg}
 done


### PR DESCRIPTION

* add installation of GoLang for darwin (macOS)
* detect GoLang on *nix and set `GOPATH` and `GOBIN` if not set
* add `GOBIN` to the `PATH`

BREAKING CHANGE:

The `git-flow-avh`, `git-extras`, and `git-flow-completion` tools are no
installed by default. While git-flow is still a fairly popular workflow
for private repositories, this prompt is designed to favor OSS
development where forks are the norm.

You can review the diff of this commit to see how they were installed on
each platform if you would like to continue using these tools.