### PR TITLE
fix(user): source user bashrc after platform

### DIFF
--- a/src/bashrc
+++ b/src/bashrc
@@ -75,10 +75,10 @@ export AM_PROMPT="$AM_HOME/prompt"
 # add scripts to path
 export PATH="$AM_PROMPT/scripts:$PATH"
 
-# source user files
-for USER_SCRIPT in $AM_PROMPT/user/*; do
-    source "$USER_SCRIPT"
-done
+# test for user variables
+if [ -f $AM_PROMPT/user/variables ]; then
+    source "$AM_PROMPT/user/variables"
+fi
 
 # test for prompt bin
 if [ -d "$AM_PROMPT/user/bin" ]; then
@@ -90,6 +90,11 @@ fi
 for EVAL_SCRIPT in $AM_PROMPT/scripts/eval/*; do
     source "$EVAL_SCRIPT"
 done
+
+# test for user bashrc
+if [ -f $AM_PROMPT/user/bashrc ]; then
+    source "$AM_PROMPT/user/bashrc"
+fi
 
 # aliases
 # -- prompt for overwrites


### PR DESCRIPTION

* test for user/variables before platform eval
* test for user/bashrc after platform eval

This is useful for scenarios where the platform eval updates the PATH
variable that user bashrc may depend on. One example would be adding
additional completions to bash for a command installed in GOBIN.