### PR TITLE
fix: remove invalid scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,15 @@
 {
     "search.exclude": {
-        "**/backup": true
+        "**/backup": true,
+        "**/node_modules/**": true
     },
     "files.exclude": {
         "**/.git": true,
         "**/.DS_Store": true,
-        "**/backup": true
+        "**/backup": true,
+        "**/node_modules/**": true
     },
-    "vsicons.presets.angular": false
+    "editor.trimAutoWhitespace": true,
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+@automotiveMastermind/Administrators
+
+CODEOWNERS @sjk07 @dmccaffery
+
+install.sh @sjk07 @dmccaffery
+/uname/ @sjk07 @dmccaffery

--- a/src/scripts/Darwin/minikube-install
+++ b/src/scripts/Darwin/minikube-install
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Minikube is now included with the installation of Docker for all platforms..."
-echo
-echo "Download docker from: https://www.docker.com/products/docker-desktop"

--- a/src/scripts/git-commits
+++ b/src/scripts/git-commits
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-git summary

--- a/src/scripts/git-lines
+++ b/src/scripts/git-lines
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-git summary --line

--- a/src/scripts/remove-backup
+++ b/src/scripts/remove-backup
@@ -7,6 +7,9 @@ __am-prompt-remove-backup() {
         BACKUP='prompt'
     fi
 
+    local REMOVE_PATH="$AM_HOME/backup/$BACKUP"
+
+    echo "removing path: $REMOVE_PATH..."
     rm -rf "$AM_HOME/backup/$BACKUP" 2>/dev/null
 }
 


### PR DESCRIPTION

* remove `git-commits` which relied on the **git-extras** package that was removed previously
* remove `git-lines` which relied on the **git-extras** package that was removed previously
* remove `minikube-install` as it is no longer necessary (for over a year)
* add `CODEOWNERS` to ensure PR approvals moving forward for vital components
* enable the following settings for the vscode editor to ensure consistency:
  * trim auto-whitespace
  * trim trailing whitespace