### PR TITLE
build: run deploy stage without rebuilding on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 jobs:
   macos:
     macos:
@@ -114,27 +114,38 @@ jobs:
           command: npm run release
 
 workflows:
+  version: 2
   install:
     jobs:
-      - macos
-      - ubuntu
-      - debian
-      - fedora-29
-      - fedora-30
-      - centos
-      - mint
-      - deploy:
-          requires:
-            - macos
-            - ubuntu
-            - debian
-            - fedora-29
-            - fedora-30
-            - centos
-            - mint
+      - macos:
           filters:
-            tags:
-              ignore:
-                - /.*/
+            branches:
+              ignore: master
+      - ubuntu:
+          filters:
+            branches:
+              ignore: master
+      - debian:
+          filters:
+            branches:
+              ignore: master
+      - fedora-29:
+          filters:
+            branches:
+              ignore: master
+      - fedora-30:
+          filters:
+            branches:
+              ignore: master
+      - centos:
+          filters:
+            branches:
+              ignore: master
+      - mint:
+          filters:
+            branches:
+              ignore: master
+      - deploy:
+          filters:
             branches:
               only: master

--- a/uname/install-debian.sh
+++ b/uname/install-debian.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 __am-prompt-install-debian() {
-    local PACKAGES=(build-essential curl file git ruby)
+    local PACKAGES=(build-essential curl file git)
 
     __am-prompt-success "updating software repositories..."
     sudo apt-get update

--- a/uname/install-ubuntu.sh
+++ b/uname/install-ubuntu.sh
@@ -1,29 +1,3 @@
 #!/usr/bin/env bash
 
-__am-prompt-install-ubuntu() {
-    local PACKAGES=(build-essential curl file git)
-
-    __am-prompt-success "updating software repositories..."
-    sudo apt-get update
-
-    __am-prompt-success "install add-apt-repository..."
-    sudo apt-get install -y software-properties-common
-
-    __am-prompt-success "setting up git-core repository..."
-    sudo add-apt-repository ppa:git-core/ppa -y
-
-    __am-prompt-success "updating software repositories..."
-    sudo apt-get update
-
-    for pkg in "${PACKAGES[@]}"; do
-        __am-prompt-success "installing $pkg..."
-        sudo apt-get install -y ${pkg}
-    done
-
-    __am-prompt-success "removing unnecessary dependencies..."
-    sudo apt-get autoremove -y
-
-    source "$SCRIPT_DIR/uname/install-linux.sh"
-}
-
-__am-prompt-install-ubuntu
+source "$SCRIPT_DIR/uname/install-debian.sh"


### PR DESCRIPTION
* remove git-core ppa from ubuntu install
  * git is now installed with brew
* setup install pipeline to only run on PRs
* setup deploy pipeline to only run on master
  * does not require a rebuild of install pipeline (this is already handled in the PR -- no reason to burn our minutes)