### PR TITLE
fix(zsh): resolve missing docker completion

### DIFF
--- a/src/bash/scripts/darwin/eval/docker-completion
+++ b/src/bash/scripts/darwin/eval/docker-completion
@@ -7,7 +7,7 @@ elif [ -d "$HOME/Applications/Docker.app/Contents/Resources/etc" ]; then
 fi
 
 if [ ! -z "${DOCKER_PATH:-}" ]; then
-    . "$DOCKER_PATH/docker.bash-completion"
-    . "$DOCKER_PATH/docker-machine.bash-completion"
-    . "$DOCKER_PATH/docker-compose.bash-completion"
+    for completion in $DOCKER_PATH/*.bash-completion; do
+        . $completion
+    done
 fi

--- a/src/zsh/install/darwin.sh
+++ b/src/zsh/install/darwin.sh
@@ -15,6 +15,24 @@ __am_prompt_install_darwin() {
             brew install $pkg
         fi
     done
+
+    # test to see if the zsh completion dir is specified
+    if [ ! -z "${ZSH_COMPLETION_DIR:-}" ]; then
+
+        # iterate over each completion
+        for completion in $ZSH_COMPLETION_DIR/*; do
+
+            # test for invalid completion
+            if [ ! -e $completion ]; then
+
+                # let the user know we're removing the invalid completion
+                $ECHO "${CLR_WARN}removing: $completion as it no longer exists...${CLR_CLEAR}"
+
+                # remove the completion
+                rm -f $completion
+            fi
+        done
+    fi
 }
 
 __am_prompt_install_darwin

--- a/src/zsh/scripts/darwin/eval/docker-completion
+++ b/src/zsh/scripts/darwin/eval/docker-completion
@@ -1,11 +1,8 @@
 #!/usr/bin/env sh
 
 if [ -d /Applications/Docker.app/Contents/Resources/etc ]; then
-
     local DOCKER_PATH=/Applications/Docker.app/Contents/Resources/etc
-
 elif [ -d "$HOME/Applications/Docker.app/Contents/Resources/etc" ]; then
-
     local DOCKER_PATH="$HOME/Applications/Docker.app/Contents/Resources/etc"
 fi
 
@@ -15,21 +12,14 @@ if [ ! -z "${DOCKER_PATH:-}" ]; then
     zstyle ':completion:*:*:docker:*' option-stacking yes
     zstyle ':completion:*:*:docker-*:*' option-stacking yes
 
-    # add completion for docker
-    if [ ! -f "${ZSH_COMPLETION_DIR}/_docker" ]; then
-        ln -s $DOCKER_PATH/docker.zsh-completion $ZSH_COMPLETION_DIR/_docker
-        . $ZSH_COMPLETION_DIR/_docker
-    fi
+    # iterate over each completion
+    for completion in $DOCKER_PATH/*.zsh-completion; do
 
-    # add completion for docker-machine
-    if [ ! -f "${ZSH_COMPLETION_DIR}/_docker-machine" ]; then
-        ln -s $DOCKER_PATH/docker-machine.zsh-completion $ZSH_COMPLETION_DIR/_docker-machine
-        . $ZSH_COMPLETION_DIR/_docker-machine
-    fi
+        ZSH_COMPLETION=${completion##*/}
+        ZSH_COMPLETION=${ZSH_COMPLETION%.*}
+        ZSH_COMPLETION="$ZSH_COMPLETION_DIR/_$ZSH_COMPLETION"
 
-    # add completion for docker-compose
-    if [ ! -f "${ZSH_COMPLETION_DIR}/_docker-compose" ]; then
-        ln -s $DOCKER_PATH/docker-compose.zsh-completion $ZSH_COMPLETION_DIR/_docker-compose
-        . $ZSH_COMPLETION_DIR/_docker-compose
-    fi
+        ln -s $completion $ZSH_COMPLETION 2>/dev/null 1>&1
+        . $ZSH_COMPLETION
+    done
 fi


### PR DESCRIPTION

* remove docker_machine completion if it is no longer available on the system
* update docker-completion evals to account for changing completions over time

NOTE:

Recent versions of Docker Desktop no longer include completions for
docker_machine which were previously symlinked to enable zsh completion
to function correctly. This update resolves the discrepancy.