### PR TITLE
fix: pushd is not posix compliant

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -85,12 +85,13 @@ __am_prompt_update()
     local PROMPT_INTALL_TEMP=$(mktemp -d)
     local PROMPT_EXTRACT_TEMP="$PROMPT_INTALL_TEMP/extract"
 
-    pushd $PROMPT_INTALL_TEMP 1>/dev/null
+    local CURRENT_DIR=${PWD}
+
+    cd $PROMPT_INTALL_TEMP 1>/dev/null
     curl -skL $PROMPT_INSTALL_URI | tar zx
-    pushd prompt-master 1>/dev/null
+    cd prompt-master 1>/dev/null
     ./install.sh $PROMPT_SHELL
-    popd 1>/dev/null
-    popd 1>/dev/null
+    cd $CURRENT_DIR
 
     rm -rf $PROMPT_INTALL_TEMP 1>/dev/null
 }

--- a/src/sh/scripts/update-prompt
+++ b/src/sh/scripts/update-prompt
@@ -87,12 +87,13 @@ __am_prompt_update()
     local PROMPT_INTALL_TEMP=$(mktemp -d)
     local PROMPT_EXTRACT_TEMP="$PROMPT_INTALL_TEMP/extract"
 
-    pushd $PROMPT_INTALL_TEMP 1>/dev/null
+    local CURRENT_DIR=${PWD}
+
+    cd $PROMPT_INTALL_TEMP 1>/dev/null
     curl -skL $PROMPT_INSTALL_URI | tar zx
-    pushd prompt-master 1>/dev/null
+    cd prompt-master 1>/dev/null
     ./install.sh $PROMPT_SHELL
-    popd 1>/dev/null
-    popd 1>/dev/null
+    cd $CURRENT_DIR
 
     rm -rf $PROMPT_INTALL_TEMP 1>/dev/null
 }

--- a/src/sh/scripts/update-sln
+++ b/src/sh/scripts/update-sln
@@ -4,7 +4,7 @@ __contains() { for item in "${@:2}"; do [[ "$item" == "$1" ]] && return 0; done;
 
 SOLUTIONS=($@)
 
-CURRENT_PATH=$(pwd)
+CURRENT_DIR=${PWD}
 
 if [ ${#SOLUTIONS[@]} -eq 0 ]; then
     SOLUTIONS=(*.sln)
@@ -25,7 +25,7 @@ for solution in "${SOLUTIONS[@]}"; do
 
     echo "Checking solution: $name"
 
-    pushd "$basepath" 1>/dev/null
+    cd "$basepath" 1>/dev/null
 
     EXISTING=($(dotnet sln "$name" list))
     EXISTING=("${EXISTING[@]:2}")
@@ -39,5 +39,5 @@ for solution in "${SOLUTIONS[@]}"; do
         __contains $discovered "${EXISTING[@]}" || dotnet sln "$name" add "$discovered"
     done
 
-    popd 1>/dev/null
+    cd $CURRENT_DIR
 done


### PR DESCRIPTION
* resolve an issue where prompt could fail to install on operating systems where the default shell is not a bash-variant where `pushd` is available
* enable prompt to be installed in WSL 2 (tested in ubuntu) through bootstrap

![image](https://user-images.githubusercontent.com/1803684/82433773-d7351a00-9a89-11ea-98d4-a6a136a2d19d.png)
