### PR TITLE
feat: add support for direnv to second line

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,26 +188,30 @@ hide-all
 
 Flush DNS:
 
-```she
+```sh
 flush-dns
 ```
 
-Install [minikube][minikube-url]:
-
-```sh
-minikube-install
-```
-
 Set Theme to Monokai:
+
 ```sh
 theme monokai # general high quality theme that has been around for many years
 ```
 
 Set Theme to Dark Mode
+
 ```sh
 theme dark-mode # our own custom theme that is nice and bright for dark mode on macOS
 ```
----
+
+### *nix Commands
+
+Install [kind][kind-url]:
+
+```sh
+kind-install
+```
+
 
 ## Copyright and License
 
@@ -226,7 +230,7 @@ theme dark-mode # our own custom theme that is nice and bright for dark mode on 
 [fossa-uri]: https://app.fossa.com/projects/custom%2B12139%2Fgit%40github.com%3AautomotiveMastermind%2Fprompt.git?ref=badge_shield
 [pyenv-url]: https://github.com/pyenv/pyenv
 [direnv-url]: https://github.com/direnv/direnv/wiki/Python
-[minikube-url]: https://minikube.sigs.k8s.io/docs/
+[kind-url]: https://kind.sigs.k8s.io
 [aws-sdk-url]: https://github.com/aws/aws-cli
 [gcloud-sdk-url]: https://cloud.google.com/sdk/install
 [dotnet-sdk-url]: https://github.com/dotnet/installer

--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@
 
 ## Vitals
 
-Info          | Badges
---------------|-------------------------------------
-License       | [![License][license-image]][license-uri]
-License Scan  | [![FOSSA Status][fossa-image]][fossa-uri]
-Build         | [![Build][build-image]][build-uri]
+| Info         | Badges                                    |
+| ------------ | ----------------------------------------- |
+| License      | [![License][license-image]][license-uri]  |
+| License Scan | [![FOSSA Status][fossa-image]][fossa-uri] |
+| Build        | [![Build][build-image]][build-uri]        |
 
 ### Supported Operating Systems
 
-Name   | Version
--------|------------------
-macOS  | Sierra or greater
-ubuntu | 16.04 or greater
-fedora | 29 or greater
-debian | 9 or greater
-centOS | 7 or greater
-mint   | 19 or greater
+| Name   | Version           |
+| ------ | ----------------- |
+| macOS  | Sierra or greater |
+| ubuntu | 16.04 or greater  |
+| fedora | 29 or greater     |
+| debian | 9 or greater      |
+| centOS | 7 or greater      |
+| mint   | 19 or greater     |
 
 ## Know It
 
@@ -37,6 +37,7 @@ including:
 * Flush DNS (on macOS)
 * Ability to enable and disable hidden files in Finder (on macOS)
 * Display of available colors (already set as variables for use elsewhere)
+* Display currently active Python virtialenv when using [pyenv][pyenv-url] & [direnv][direnv-url] (bash & zsh)
 * ... and much more!
 
 Note: All "extensions" are implemented as scripts added to the path, so it should not interfere with existing
@@ -121,6 +122,93 @@ In order to test the installation routine for promptMastermind, we use a set of 
 In addition, [circleci][circleci-uri] is used to build all platforms, including macOS as part of our pull request
 validation. Special thanks to [circleci][circleci-uri] for providing the build agents!
 
+## Features
+
+### Two-Line Prompt
+
+The first-line displays username, hostname, and current path.
+
+The second-line emits information about the current branch and status when in a git path. If using [pyenv][pyenv-url] and [direnv][direnv-url] the second-line also displays the currently activated Python virtualenv.
+
+### SDK Installs
+
+[AWS SDK][aws-sdk-url]
+
+```sh
+aws-install
+```
+
+[Google Cloud SDK][gcloud-sdk-url]
+
+```sh
+gcloud-install
+```
+
+[.Net SDK][dotnet-sdk-url]
+
+```sh
+dotnet-install
+```
+
+### Colors
+
+Glocal colors defined by promotMastermind:
+
+| Name               | Color                   |
+| ------------------ | ----------------------- |
+| CLR_CLEAR          | DEFAULT COLOR           |
+| CLR_BLACK          | ANSI BLACK (GRAY)       |
+| CLR_RED            | ANSI RED                |
+| CLR_GREEN          | ANSI GREEN              |
+| CLR_YELLOW         | ANSI YELLOW             |
+| CLR_BLUE           | ANSI BLUE               |
+| CLR_MAGENTA        | ANSI MAGENTA (PURPLE)   |
+| CLR_CYAN           | ANSI CYAN               |
+| CLR_WHITE          | ANSI WHITE              |
+| CLR_BRIGHT_BLACK   | BRIGHT BLACK (GRAY)     |
+| CLR_BRIGHT_RED     | BRIGHT RED              |
+| CLR_BRIGHT_GREEN   | BRIGHT GREEN            |
+| CLR_BRIGHT_YELLOW  | BRIGHT YELLOW           |
+| CLR_BRIGHT_BLUE    | BRIGHT BLUE             |
+| CLR_BRIGHT_MAGENTA | BRIGHT MAGENTA (PURPLE) |
+| CLR_BRIGHT_CYAN    | BRIGHT CYAN             |
+| CLR_BRIGHT_WHITE   | BRIGHT WHITE            |
+
+### macOS Commands
+
+Show/Hide Files:
+
+```sh
+# show all hidden files
+show-all
+
+# hide all hidden files
+hide-all
+```
+
+Flush DNS:
+
+```she
+flush-dns
+```
+
+Install [minikube][minikube-url]:
+
+```sh
+minikube-install
+```
+
+Set Theme to Monokai:
+```sh
+theme monokai # general high quality theme that has been around for many years
+```
+
+Set Theme to Dark Mode
+```sh
+theme dark-mode # our own custom theme that is nice and bright for dark mode on macOS
+```
+---
+
 ## Copyright and License
 
 &copy; automotiveMastermind and contributors. Distributed under the MIT license. See [LICENSE][license-uri] for details.
@@ -136,3 +224,9 @@ validation. Special thanks to [circleci][circleci-uri] for providing the build a
 
 [fossa-image]: https://app.fossa.com/api/projects/custom%2B12139%2Fgit%40github.com%3AautomotiveMastermind%2Fprompt.git.svg?type=shield
 [fossa-uri]: https://app.fossa.com/projects/custom%2B12139%2Fgit%40github.com%3AautomotiveMastermind%2Fprompt.git?ref=badge_shield
+[pyenv-url]: https://github.com/pyenv/pyenv
+[direnv-url]: https://github.com/direnv/direnv/wiki/Python
+[minikube-url]: https://minikube.sigs.k8s.io/docs/
+[aws-sdk-url]: https://github.com/aws/aws-cli
+[gcloud-sdk-url]: https://cloud.google.com/sdk/install
+[dotnet-sdk-url]: https://github.com/dotnet/installer

--- a/src/bash/scripts/eval/set-prompt
+++ b/src/bash/scripts/eval/set-prompt
@@ -26,12 +26,6 @@ __am_prompt_emit_prompt_arrow() {
     fi
 }
 
-__am_prompt_show_virtual_env() {
-  if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
-    echo "($(basename $VIRTUAL_ENV)) "
-  fi
-}
-
 __am_prompt_set_prompt() {
 
     # set the window title
@@ -41,7 +35,7 @@ __am_prompt_set_prompt() {
         export PROMPT_COMMAND='"\n\u@\h : \w\n" "$(__am_prompt_emit_prompt_arrow)"'
     else
         # use the git prompt with the prompt arrow
-        export PROMPT_COMMAND='__posh_git_ps1 "\n\u@\h : \w\n" "$(__am_prompt_show_virtual_env)$(__am_prompt_emit_prompt_arrow)"'
+        export PROMPT_COMMAND='__posh_git_ps1 "\n\u@\h : \w\n" "$(__am_prompt_show_virtual_env) $(__am_prompt_emit_prompt_arrow)"'
     fi
 }
 

--- a/src/bash/scripts/eval/set-prompt
+++ b/src/bash/scripts/eval/set-prompt
@@ -26,6 +26,12 @@ __am_prompt_emit_prompt_arrow() {
     fi
 }
 
+__am_prompt_show_virtual_env() {
+  if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
+    echo "($(basename $VIRTUAL_ENV)) "
+  fi
+}
+
 __am_prompt_set_prompt() {
 
     # set the window title
@@ -35,7 +41,7 @@ __am_prompt_set_prompt() {
         export PROMPT_COMMAND='"\n\u@\h : \w\n" "$(__am_prompt_emit_prompt_arrow)"'
     else
         # use the git prompt with the prompt arrow
-        export PROMPT_COMMAND='__posh_git_ps1 "\n\u@\h : \w\n" "$(__am_prompt_emit_prompt_arrow)"'
+        export PROMPT_COMMAND='__posh_git_ps1 "\n\u@\h : \w\n" "$(__am_prompt_show_virtual_env)$(__am_prompt_emit_prompt_arrow)"'
     fi
 }
 

--- a/src/bash/scripts/eval/show-virtualenv
+++ b/src/bash/scripts/eval/show-virtualenv
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# if virutal env and direnv variables are set show virtual env in prompt
+__am_prompt_show_virtual_env() {
+    if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
+        echo "(${VIRTUAL_ENV##*/})"
+    fi
+    }
+
+__am_prompt_show_virtual_env

--- a/src/zsh/scripts/eval/set-prompt
+++ b/src/zsh/scripts/eval/set-prompt
@@ -27,7 +27,7 @@ __am_prompt_emit_prompt_arrow() {
     fi
 }
 
-__am_prompt_set_direnv() {
+__am_prompt_show_virtualenv() {
     if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
         setopt PROMPT_SUBST
         export DIR_ENV=" ($(basename $VIRTUAL_ENV))"

--- a/src/zsh/scripts/eval/set-prompt
+++ b/src/zsh/scripts/eval/set-prompt
@@ -27,25 +27,20 @@ __am_prompt_emit_prompt_arrow() {
     fi
 }
 
-__am_prompt_show_virtualenv() {
-    if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
-        setopt PROMPT_SUBST
-        export DIR_ENV=" ($(basename $VIRTUAL_ENV))"
-    else
-        export DIR_ENV=""
-    fi
-}
-
 __am_prompt_set_prompt() {
     # set the window title
     echo -ne "\033]0;${USER}@${HOSTNAME%%.*} ${PWD}\007"
 
+    if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
+        setopt PROMPT_SUBST
+        local DIR_ENV="(${VIRTUAL_ENV##*/})"
+    else
+        local DIR_ENV=""
+    fi
+
     local NEWLINE=$'\n'
     __posh_git_ps1 "${NEWLINE}%n@%m : %~${NEWLINE}" "$DIR_ENV $AM_PROMPT_ARROW"
 }
-
-# set the direnv if exists
-__am_prompt_show_virtualenv
 
 # set up the arrow
 __am_prompt_emit_prompt_arrow

--- a/src/zsh/scripts/eval/set-prompt
+++ b/src/zsh/scripts/eval/set-prompt
@@ -45,7 +45,7 @@ __am_prompt_set_prompt() {
 }
 
 # set the direnv if exists
-__am_prompt_set_direnv
+__am_prompt_show_virtualenv
 
 # set up the arrow
 __am_prompt_emit_prompt_arrow

--- a/src/zsh/scripts/eval/set-prompt
+++ b/src/zsh/scripts/eval/set-prompt
@@ -27,13 +27,25 @@ __am_prompt_emit_prompt_arrow() {
     fi
 }
 
+__am_prompt_set_direnv() {
+    if [[ -n "$VIRTUAL_ENV" && -n "$DIRENV_DIR" ]]; then
+        setopt PROMPT_SUBST
+        export DIR_ENV=" ($(basename $VIRTUAL_ENV))"
+    else
+        export DIR_ENV=""
+    fi
+}
+
 __am_prompt_set_prompt() {
     # set the window title
     echo -ne "\033]0;${USER}@${HOSTNAME%%.*} ${PWD}\007"
 
     local NEWLINE=$'\n'
-    __posh_git_ps1 "${NEWLINE}%n@%m : %~${NEWLINE}" " $AM_PROMPT_ARROW"
+    __posh_git_ps1 "${NEWLINE}%n@%m : %~${NEWLINE}" "$DIR_ENV $AM_PROMPT_ARROW"
 }
+
+# set the direnv if exists
+__am_prompt_set_direnv
 
 # set up the arrow
 __am_prompt_emit_prompt_arrow


### PR DESCRIPTION
Add support for displaying the current directory's Python virtual environment when [direnv](https://direnv.net) and [pyenv](https://github.com/pyenv/pyenv) are installed and being used.

<img width="841" alt="image" src="https://user-images.githubusercontent.com/1302453/83426876-d42d1880-a3fd-11ea-8fd7-499805d0d114.png">