### PR TITLE
workflow(release): install semantic-release plugins

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - build/*
       - master
       - next
       - +([0-9])?(.{+([0-9]),x}).x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,23 @@ jobs:
       - name: install-node
         uses: actions/setup-node@master
 
+      - name: semantic-release-prerequisites
+        run: |
+          npm install --no-package-lock --no-save \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/changelog \
+            @semantic-release/exec \
+            @semantic-release/github
+
+      - name: semantic-release-dry-run
+        run: npx semantic-release --ci --dry-run
+        if: ${{ github.event.repository.fork }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: semantic-release
-        run: npx semantic-release
+        run: npx semantic-release --ci
+        if: ${{ !github.event.repository.fork }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/sh/install/debian.sh
+++ b/src/sh/install/debian.sh
@@ -4,7 +4,7 @@ set -e
 
 __am_prompt_install_debian() {
     local SUDO=$(command -v sudo 2>/dev/null || "")
-    local PACKAGES='sudo build-essential curl file git bash'
+    local PACKAGES='sudo build-essential curl file git bash procps'
 
     $ECHO "${CLR_SUCCESS}updating software repositories...${CLR_CLEAR}"
     $SUDO apt-get update


### PR DESCRIPTION
* install all plugins used by the semantic release pipeline

This commit should repair the broken release build caused by the introduction of the changelog plugin. Our CHANGELOG hasn't been updated in 5 months. O.o