### PR TITLE
fix: ensure update-prompt can use release channels

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -69,31 +69,27 @@ __am_prompt_update()
 
         # print latest version already installed
         if [ "${PROMPT_SHA}" = "${PROMPT_CURRENT_SHA}" ]; then
-            echo "${CLR_SUCCESS}prompt: latest version already installed: ${PROMPT_SHA}.${CLR_CLEAR}"
+            echo "${CLR_SUCCESS}prompt: latest version already installed: ${PROMPT_SHA}"
             echo "  - run update-prompt with the --force flag to reinstall ${CLR_CLEAR}"
             exit 0
         fi
     fi
 
     if [ ! -z "${PROMPT_DRY_RUN:-}" ]; then
-        echo "${CLR_WARN}prompt: a new version of prompt is available: ${PROMPT_SHA}."
+        echo "${CLR_WARN}prompt: a new version of prompt is available: ${PROMPT_SHA}"
         echo "  - run the update-prompt command line tool to upgrade${CLR_CLEAR}"
         return 0
     fi
 
     local PROMPT_INSTALL_URI="https://github.com/automotiveMastermind/prompt/archive/$PROMPT_COMMIT_REF.tar.gz"
-    local PROMPT_INTALL_TEMP=$(mktemp -d)
-    local PROMPT_EXTRACT_TEMP="$PROMPT_INTALL_TEMP/extract"
+    local PROMPT_INSTALL_TEMP=$(mktemp -d)
 
-    local CURRENT_DIR=${PWD}
+    curl -skLo $PROMPT_INSTALL_TEMP/prompt.tgz $PROMPT_INSTALL_URI
+    tar -xzf $PROMPT_INSTALL_TEMP/prompt.tgz --strip-components=1 --directory=$PROMPT_INSTALL_TEMP
 
-    cd $PROMPT_INTALL_TEMP 1>/dev/null
-    curl -skL $PROMPT_INSTALL_URI | tar zx
-    cd prompt-master 1>/dev/null
-    ./install.sh $PROMPT_SHELL
-    cd $CURRENT_DIR
-
-    rm -rf $PROMPT_INTALL_TEMP 1>/dev/null
+    . "$PROMPT_INSTALL_TEMP/install.sh" $PROMPT_SHELL
 }
+
+trap 'echo; echo; echo "${CLR_WARN}prompt: terminating update...${CLR_CLEAR}"; exit -1;' INT
 
 __am_prompt_update $@

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
 CLR_SUCCESS="\033[1;32m"    # BRIGHT GREEN
 CLR_WARN="\033[1;33m"       # BRIGHT YELLOW
 CLR_CLEAR="\033[0m"         # DEFAULT COLOR
@@ -46,25 +48,25 @@ __am_prompt_install() {
         cp -R $AM_PROMPT/* "$BACKUP_PATH" 1>/dev/null
 
         __am_prompt_success "removing $AM_PROMPT"
-        rm -rf "$AM_PROMPT/bash" 1>/dev/null 2>&1
-        rm -rf "$AM_PROMPT/sh" 1>/dev/null 2>&1
-        rm -rf "$AM_PROMPT/zsh" 1>/dev/null 2>&1
-        rm -rf "$AM_PROMPT/themes" 1>/dev/null 2>&1
+        rm -rf "$AM_PROMPT/bash"    1>/dev/null 2>&1
+        rm -rf "$AM_PROMPT/sh"      1>/dev/null 2>&1
+        rm -rf "$AM_PROMPT/zsh"     1>/dev/null 2>&1
+        rm -rf "$AM_PROMPT/themes"  1>/dev/null 2>&1
 
         # remove legacy paths
         rm -rf "$AM_PROMPT/completions" 1>/dev/null 2>&1
-        rm -rf "$AM_PROMPT/scripts" 1>/dev/null 2>&1
-        rm -f "$AM_PROMPT/bashrc" 1>/dev/null 2>&1
+        rm -rf "$AM_PROMPT/scripts"     1>/dev/null 2>&1
+        rm -f "$AM_PROMPT/bashrc"       1>/dev/null 2>&1
     fi
 
     __am_prompt_success "creating $AM_PROMPT"
     mkdir -p "$AM_PROMPT/user" 1>/dev/null 2>&1
 
     __am_prompt_success "installing promptMastermind to $AM_PROMPT"
-    cp -Rf src/bash "$AM_PROMPT" 1>/dev/null
-    cp -Rf src/sh "$AM_PROMPT" 1>/dev/null
-    cp -Rf src/zsh "$AM_PROMPT" 1>/dev/null
-    cp -Rf src/themes "$AM_PROMPT" 1>/dev/null
+    cp -Rf "$SCRIPT_DIR/src/bash"   "$AM_PROMPT" 1>/dev/null
+    cp -Rf "$SCRIPT_DIR/src/sh"     "$AM_PROMPT" 1>/dev/null
+    cp -Rf "$SCRIPT_DIR/src/zsh"    "$AM_PROMPT" 1>/dev/null
+    cp -Rf "$SCRIPT_DIR/src/themes" "$AM_PROMPT" 1>/dev/null
 
     for USER_ITEM in src/user/*; do
         local USER_ITEM_NAME=$(basename "$USER_ITEM")
@@ -120,7 +122,6 @@ __am_prompt_install() {
 
     local PROMPT_SHA=$(cat VERSION)
     local PROMPT_SHA_PATH=$HOME/.am/prompt/.sha
-    local PROMPT_CHANGELOG_URL="https://github.com/automotivemastermind/prompt/blob/$PROMPT_SHA/CHANGELOG.md"
 
     echo $PROMPT_SHA > $PROMPT_SHA_PATH
 
@@ -145,10 +146,16 @@ __am_prompt_install() {
     local PROMPT_SHELL=$(echo $PROMPT_SHELL | tr '[:upper:]' '[:lower:]')
 
     # use the correct shell
-    . $AM_PROMPT/sh/scripts/use-shell $PROMPT_SHELL
+    . "$AM_PROMPT/sh/scripts/use-shell" $PROMPT_SHELL
 
     # open the changelog url
-    . $AM_PROMPT/sh/scripts/open-url $PROMPT_CHANGELOG_URL
+    . "$AM_PROMPT/sh/scripts/open-url" "https://github.com/automotivemastermind/prompt/blob/$PROMPT_SHA/CHANGELOG.md"
 }
+
+echo
+echo "${CLR_WARN}prompt: establishing sudo (you may be prompted for credentials)...${CLR_CLEAR}"
+sudo echo
+
+trap 'echo; echo; echo "${CLR_WARN}prompt: terminating install...${CLR_CLEAR}"; exit -1;' INT
 
 __am_prompt_install $@

--- a/src/sh/install/darwin.sh
+++ b/src/sh/install/darwin.sh
@@ -25,9 +25,9 @@ __am_prompt_ensure_rosetta() {
     $ECHO "    - /usr/local    : x86_64 emulation via Rosetta 2                          "
     $ECHO
     $ECHO "  The Apple Silicon (arm64e) version will be the default as it will be placed "
-    $ECHO "  on the PATH variable before the native version. This is compatible with more"
-    $ECHO "  formulae at this time. To use the intel (x86_64) version, you can use the   "
-    $ECHO "  \`brew-intel\` alias. For example:                                          "
+    $ECHO "  on the PATH variable before the native version. While this is not compatible"
+    $ECHO "  with most formulae, we expect this to improve over time. To use the         "
+    $ECHO "  intel (x86_64) version, you can use the \`brew-intel\` alias. For example:  "
     $ECHO
     $ECHO "  brew-intel install git                                                      "
     $ECHO

--- a/src/sh/scripts/update-prompt
+++ b/src/sh/scripts/update-prompt
@@ -69,33 +69,27 @@ __am_prompt_update()
 
         # print latest version already installed
         if [ "${PROMPT_SHA}" = "${PROMPT_CURRENT_SHA}" ]; then
-            echo "${CLR_SUCCESS}prompt: latest version already installed: ${PROMPT_SHA}.${CLR_CLEAR}"
+            echo "${CLR_SUCCESS}prompt: latest version already installed: ${PROMPT_SHA}"
+            echo "  - run update-prompt with the --force flag to reinstall ${CLR_CLEAR}"
             exit 0
         fi
     fi
 
     if [ ! -z "${PROMPT_DRY_RUN:-}" ]; then
-        echo "${CLR_WARN}prompt: a new version of prompt is available: ${PROMPT_SHA}."
+        echo "${CLR_WARN}prompt: a new version of prompt is available: ${PROMPT_SHA}"
         echo "  - run the update-prompt command line tool to upgrade${CLR_CLEAR}"
         return 0
     fi
 
-    remove-backup
-
-    local PROMPT_CHANGELOG_URI="https://github.com/automotivemastermind/prompt/blob/$PROMPT_COMMIT_REF/CHANGELOG.md"
     local PROMPT_INSTALL_URI="https://github.com/automotiveMastermind/prompt/archive/$PROMPT_COMMIT_REF.tar.gz"
-    local PROMPT_INTALL_TEMP=$(mktemp -d)
-    local PROMPT_EXTRACT_TEMP="$PROMPT_INTALL_TEMP/extract"
+    local PROMPT_INSTALL_TEMP=$(mktemp -d)
 
-    local CURRENT_DIR=${PWD}
+    curl -skLo $PROMPT_INSTALL_TEMP/prompt.tgz $PROMPT_INSTALL_URI
+    tar -xzf $PROMPT_INSTALL_TEMP/prompt.tgz --strip-components=1 --directory=$PROMPT_INSTALL_TEMP
 
-    cd $PROMPT_INTALL_TEMP 1>/dev/null
-    curl -skL $PROMPT_INSTALL_URI | tar zx
-    cd prompt-master 1>/dev/null
-    ./install.sh $PROMPT_SHELL
-    cd $CURRENT_DIR
-
-    rm -rf $PROMPT_INTALL_TEMP 1>/dev/null
+    . "$PROMPT_INSTALL_TEMP/install.sh" $PROMPT_SHELL
 }
+
+trap 'echo; echo; echo "${CLR_WARN}prompt: terminating update...${CLR_CLEAR}"; exit -1;' INT
 
 __am_prompt_update $@

--- a/src/zsh/zshrc
+++ b/src/zsh/zshrc
@@ -15,7 +15,8 @@ if [ -t 1 ]; then
 fi
 
 # shell options
-setopt CDABLE_VARS
+setopt cdable_vars
+setopt inc_append_history
 
 # rebuild completion
 rm -rf $HOME/.zcompdump


### PR DESCRIPTION
fix: ensure update-prompt can use release channels
feat(zsh): enable history across terminal sessions
docs(darwin): correct warning for apple silicon detection